### PR TITLE
Fix .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .DS_Store
-/node_modules
+.idea


### PR DESCRIPTION
`node_modules` are required for plugin execution